### PR TITLE
Solved the memory peak in between user input and response output

### DIFF
--- a/gbx_lm/examples/config.py
+++ b/gbx_lm/examples/config.py
@@ -1,0 +1,61 @@
+"""
+Tokens' configuration for different models(DeepSeek R1/Qwen3/Llama3)
+"""
+
+class ModelConfig:
+    MODEL_CONFIGS = {
+        # Llama3 series models
+        "llama3": {
+            "use_update_after_step": True,
+            "generation_tokens": [128006, 78191, 128007, 271],
+            "description": "tokens thatLlama3 series models used for update_after_step function"
+        },
+        
+        # Qwen3 series models
+        "qwen3": {
+            "use_update_after_step": True,
+            "generation_tokens": [151644, 77091, 198],
+            "description": "tokens that Qwen3 series models used for update_after_step function"
+        },
+        
+        # DeepSeek series models
+        "deepseek": {
+            "use_update_after_step": False,
+            "generation_tokens": [],  # DeepSeek uses update method, no specific tokens are needed
+            "description": "tokens that DeepSeek series models used for update_after_step function"
+        }
+    }
+    
+    @classmethod
+    def get_model_type(cls, model_name: str) -> str:
+        """
+        infer model type from model name
+        Args:
+            model_name: model name
+        Returns:
+            model type string
+        """
+        model_name_lower = model_name.lower()
+        #There is a problem: if the model name contains both qwen3 and deepseek, it will be recognized as deepseek first(因为我看公司已有的模型这两个明细同时出现的都是deepseek)
+        if "llama3" in model_name_lower or "llama-3" in model_name_lower:
+            return "llama3"
+        elif "deepseek" in model_name_lower or "deepseek-r1" in model_name_lower:
+            return "deepseek"
+        elif "qwen3" in model_name_lower or "qwen-3" in model_name_lower:
+            return "qwen3"
+        else:
+            # default to qwen3 configuration
+            print(f"Warning: unrecognized model type {model_name}, using default configuration(qwen3)")
+            return "qwen3"
+    
+    @classmethod
+    def get_config(cls, model_name: str) -> dict:
+        """
+        get model configuration
+        Args:
+            model_name: model name
+        Returns:
+            model configuration dictionary
+        """
+        model_type = cls.get_model_type(model_name)
+        return cls.MODEL_CONFIGS[model_type].copy()

--- a/gbx_lm/infer_opt.py
+++ b/gbx_lm/infer_opt.py
@@ -163,7 +163,7 @@ def generate_response(
     )
     response = tokenizer.decode(np.array(generated_ids), skip_special_tokens=True)
     response = response.strip()
-    return response
+    return response, generated_ids
 
 def eminf_generate_step(
     model, tokenizer, input_ids, input_ids_no_gen, max_tokens, num_steps=None, alpha=0.65,


### PR DESCRIPTION
Overview of this PR:
1. I improved the `update_after_step` function. Through this function, I update `self.tokens_no_gen` after every generation of response, so that the assistant response can be counted into the common prefix and no longer part of the delta(new content that will be forwarded to the model as new input). Forwarding less content to the model means less usage of memory and faster response speed. 
The reason why I am adding "generation tokens"(e.g. [151644, 77091, 198]) these are the `<imstart>` tokens. Since I am not using `apply_chat_template` function so I have to manually add the imstart tokens. Why I can't use `apply chat template`: `apply_chat_template `will add <think> <\think> tokens automatically to the assistant part in the token id list, which will interfere with the common prefix calculation. THIS IS THE MAIN CAUSE why the assistant response previously couldn't be calculated as common prefix. 因为有这个think干扰所以assistant response之后的部分被判定成了增量/不同的新部分，但事实上assistant response应该是共同前缀的一部分。

2. Created config.py to fit different cases for different models(Qwen3/Llama3/DeepSeek R1)
3. After tested, I found that `mx.metal.clear_cache()` may not be very necessary for reducing memory usage, so I deleted them to make the whole code look cleaner